### PR TITLE
chore: Change the BreadCrumbs component's class argument names and default values

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,11 @@ ember install @bagaar/ember-breadcrumbs
 ```handlebars
 {{! app/templates/application.hbs }}
 
-<Breadcrumbs />
+<Breadcrumbs
+  class="breadcrumbs"
+  @itemClass="breadcrumbs__item"
+  @linkClass="breadcrumbs__link"
+/>
 ```
 
 > **NOTE:** It's also possible to render multiple instances of the `<Breadcrumbs />` component.
@@ -38,8 +42,8 @@ ember install @bagaar/ember-breadcrumbs
 ```handlebars
 {{! app/templates/foo.hbs }}
 
-<BreadcrumbsItem as |linkClassName|>
-  {{#link-to "foo" class=linkClassName}}
+<BreadcrumbsItem as |linkClass|>
+  {{#link-to "foo" class=linkClass}}
     Foo
   {{/link-to}}
 </BreadcrumbsItem>
@@ -48,8 +52,8 @@ ember install @bagaar/ember-breadcrumbs
 ```handlebars
 {{! app/templates/foo/bar.hbs }}
 
-<BreadcrumbsItem as |linkClassName|>
-  {{#link-to "foo.bar" class=linkClassName}}
+<BreadcrumbsItem as |linkClass|>
+  {{#link-to "foo.bar" class=linkClass}}
     Bar
   {{/link-to}}
 </BreadcrumbsItem>
@@ -84,15 +88,14 @@ The rendered output will be:
 
 ### 3\. Styling the Breadcrumbs
 
-The addon doesn't ship with default styling, this should be done inside the consuming project.
+The addon doesn't ship with default styling. This should be done inside the consuming project.
 
-### 4\. Arguments
+### 4\. `<Breadcrumbs />` arguments
 
-Name              | Description               | Type   | Default
-:---------------- | :------------------------ | :----- | :------------------
-**className**     | The component class name. | String | 'breadcrumbs'
-**itemClassName** | The item class name.      | String | 'breadcrumbs__item'
-**linkClassName** | The link class name.      | String | 'breadcrumbs__link'
+Name          | Description                                                                      | Type   
+:-------------| :------------------------------------------------------------------------------- | :----- 
+**itemClass** | The class(es) that will be added to all child `<BreadcrumbsItem />` components   | String 
+**linkClass** | The class(es) that will be yielded to the `<BreadcrumbsItem />`'s block content  | String 
 
 ## Usage Inside an Engine
 

--- a/addon/components/breadcrumbs.js
+++ b/addon/components/breadcrumbs.js
@@ -13,15 +13,13 @@ export default Component.extend({
    * Arguments
    */
 
-  className: 'breadcrumbs',
-  itemClassName: 'breadcrumbs__item',
-  linkClassName: 'breadcrumbs__link',
+  itemClass: null,
+  linkClass: null,
 
   /**
    * State
    */
 
-  classNameBindings: ['className'],
   layout,
   tagName: 'ul',
 

--- a/addon/templates/components/breadcrumbs-item.hbs
+++ b/addon/templates/components/breadcrumbs-item.hbs
@@ -1,7 +1,7 @@
 {{#each breadcrumbsService.instances as |instance|}}
   {{#-in-element instance.element}}
-    <li class={{instance.itemClassName}}>
-      {{yield instance.linkClassName}}
+    <li class={{instance.itemClass}}>
+      {{yield instance.linkClass}}
     </li>
   {{/-in-element}}
 {{/each}}

--- a/tests/dummy/app/templates/foo.hbs
+++ b/tests/dummy/app/templates/foo.hbs
@@ -1,5 +1,5 @@
-<BreadcrumbsItem as |linkClassName|>
-  {{link-to "Foo" "foo" class=linkClassName}}
+<BreadcrumbsItem as |linkClass|>
+  {{link-to "Foo" "foo" class=linkClass}}
 </BreadcrumbsItem>
 
 {{outlet}}

--- a/tests/dummy/app/templates/foo/bar.hbs
+++ b/tests/dummy/app/templates/foo/bar.hbs
@@ -1,5 +1,5 @@
-<BreadcrumbsItem as |linkClassName|>
-  {{link-to "Bar" "foo.bar" class=linkClassName}}
+<BreadcrumbsItem as |linkClass|>
+  {{link-to "Bar" "foo.bar" class=linkClass}}
 </BreadcrumbsItem>
 
 {{outlet}}

--- a/tests/dummy/app/templates/foo/bar/baz.hbs
+++ b/tests/dummy/app/templates/foo/bar/baz.hbs
@@ -1,8 +1,8 @@
 Breadcrumbs 2:
 <Breadcrumbs />
 
-<BreadcrumbsItem as |linkClassName|>
-  {{link-to "Baz" "foo.bar.baz" class=linkClassName}}
+<BreadcrumbsItem as |linkClass|>
+  {{link-to "Baz" "foo.bar.baz" class=linkClass}}
 </BreadcrumbsItem>
 
 {{outlet}}

--- a/tests/integration/components/breadcrumbs-item-test.js
+++ b/tests/integration/components/breadcrumbs-item-test.js
@@ -9,13 +9,13 @@ module('Integration | Component | breadcrumbs-item', function (hooks) {
   test('it renders the correct class names', async function (assert) {
     await render(hbs`
       <Breadcrumbs
-        @className="class-name"
-        @itemClassName="item-class-name"
-        @linkClassName="link-class-name"
+        class="class-name"
+        @itemClass="item-class-name"
+        @linkClass="link-class-name"
       />
 
-      <BreadcrumbsItem as |linkClassName|>
-        {{link-to "Foo" "foo" class=linkClassName}}
+      <BreadcrumbsItem as |linkClass|>
+        {{link-to "Foo" "foo" class=linkClass}}
       </BreadcrumbsItem>
     `)
 

--- a/tests/integration/components/breadcrumbs-test.js
+++ b/tests/integration/components/breadcrumbs-test.js
@@ -7,15 +7,15 @@ module('Integration | Component | breadcrumbs', function (hooks) {
   setupRenderingTest(hooks)
 
   test('it renders the correct base class name', async function (assert) {
-    await render(hbs`<Breadcrumbs @className="class-name" />`)
+    await render(hbs`<Breadcrumbs class="class-name" />`)
 
     assert.ok(this.element.querySelector('.class-name'))
   })
 
   test('it renders multiple instances with the correct base class name', async function (assert) {
     await render(hbs`
-      <Breadcrumbs @className="class-name-1" />
-      <Breadcrumbs @className="class-name-2" />
+      <Breadcrumbs class="class-name-1" />
+      <Breadcrumbs class="class-name-2" />
     `)
 
     assert.ok(this.element.querySelector('.class-name-1'))


### PR DESCRIPTION
BREAKING CHANGE:
- Removed the default values for the class arguments
- Removed the `@className` argument since the `class` html attribute can fully replace it
- Renamed `itemClassName` to `itemClass`
- Renamed `linkClassName` to `linkClass`