### PR TITLE
Replace `inject` with `service`

### DIFF
--- a/ember-breadcrumbs/src/-private/breadcrumbs-container-modifier.ts
+++ b/ember-breadcrumbs/src/-private/breadcrumbs-container-modifier.ts
@@ -1,5 +1,5 @@
 import { registerDestructor } from '@ember/destroyable';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Modifier, { type NamedArgs, type PositionalArgs } from 'ember-modifier';
 import BreadcrumbsService, { type Container } from '../services/breadcrumbs.ts';
 

--- a/ember-breadcrumbs/src/components/breadcrumbs-item.gts
+++ b/ember-breadcrumbs/src/components/breadcrumbs-item.gts
@@ -1,4 +1,4 @@
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import BreadcrumbsService from '../services/breadcrumbs.ts';
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -142,8 +142,8 @@ importers:
         specifier: ^3.2.1
         version: 3.3.0(@glint/template@1.3.0)(ember-source@5.6.0)(webpack@5.90.3)
       '@embroider/test-setup':
-        specifier: ^3.0.1
-        version: 3.0.3
+        specifier: ^4.0.0
+        version: 4.0.0
       '@glimmer/component':
         specifier: ^1.1.2
         version: 1.1.2(@babel/core@7.24.0)
@@ -1845,13 +1845,13 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
-  /@embroider/test-setup@3.0.3:
-    resolution: {integrity: sha512-3K5KSyTdnxAkZQill6+TdC/XTRr6226LNwZMsrhRbBM0FFZXw2D8qmJSHPvZLheQx3A1jnF9t1lyrAzrKlg6Yw==}
+  /@embroider/test-setup@4.0.0:
+    resolution: {integrity: sha512-1S3Ebk0CEh3XDqD93AWSwQZBCk+oGv03gtkaGgdgyXGIR7jrVyDgEnEuslN/hJ0cuU8TqhiXrzHMw7bJwIGhWw==}
     engines: {node: 12.* || 14.* || >= 16}
     peerDependencies:
-      '@embroider/compat': ^3.3.0
-      '@embroider/core': ^3.4.0
-      '@embroider/webpack': ^3.2.1
+      '@embroider/compat': ^3.4.8
+      '@embroider/core': ^3.4.8
+      '@embroider/webpack': ^4.0.0
     peerDependenciesMeta:
       '@embroider/compat':
         optional: true

--- a/test-app/package.json
+++ b/test-app/package.json
@@ -30,7 +30,7 @@
     "@ember/optional-features": "^2.0.0",
     "@ember/string": "^3.1.1",
     "@ember/test-helpers": "^3.2.1",
-    "@embroider/test-setup": "^3.0.1",
+    "@embroider/test-setup": "^4.0.0",
     "@glimmer/component": "^1.1.2",
     "@glimmer/tracking": "^1.1.2",
     "@glint/environment-ember-loose": "^1.3.0",


### PR DESCRIPTION
`inject` has been deprecated in Ember 6.3 and `service` has been supported since Ember 4.1 so we can safely switch to the newer import.

More information:
- https://deprecations.emberjs.com/id/importing-inject-from-ember-service
- https://blog.emberjs.com/ember-4-1-released